### PR TITLE
Specify that source files are written in UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,11 @@
  */
 
 plugins {
-  // Apply the application plugin to add support for building a CLI application
+  // Apply the application plugin to add support for building a CLI application.
   id 'application'
 }
 
-// In this section you declare where to find the dependencies of your project
+// In this section you declare where to find the dependencies of your project.
 repositories {
   // Use jcenter for resolving your dependencies.
   // You can declare any Maven/Ivy/file repository here.
@@ -32,11 +32,16 @@ dependencies {
 }
 
 application {
-  // Define the main class for the application
+  // Define the main class for the application.
   mainClass.set('hellos.Hellos')
 }
 
 test {
-  // Use junit platform for unit tests
+  // Use junit platform for unit tests.
   useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile) {
+  // All of our source files are written in UTF-8.
+  options.encoding = 'UTF-8'
 }


### PR DESCRIPTION
Previously, we weren't telling Gradle what encoding we're using for our Java files, so Gradle was just guessing. (On *nix, it was guessing UTF-8, but on Windows, it was guessing Windows-1252.) This meant that on Windows, any non-ASCII characters got misinterpreted (which lead to failing tests).

@floogulinc noticed that there are also some issues with the encoding Java uses to print non-ASCII characters. That's its own separate issue, though—and one beyond the scope of this pull request. 🙂

(I'll make a PR identical to this one in the `UMM-CSci-3601/intro-to-git` repository.)

Closes #28.